### PR TITLE
Stepper Issue

### DIFF
--- a/olake_frontend/src/modules/jobs/pages/JobCreation.tsx
+++ b/olake_frontend/src/modules/jobs/pages/JobCreation.tsx
@@ -143,18 +143,18 @@ const JobCreation: React.FC = () => {
 					</Link>
 
 					{/* Stepper */}
-					<div className="flex items-center">
+					<div className="flex items-center gap-2">
 						<div className="flex flex-col items-start">
 							<div className="flex items-center">
 								<div
-									className={`rounded-full border ${currentStep === "source" || currentStep === "destination" || currentStep === "schema" || currentStep === "config" ? "size-2 border-blue-600 outline outline-2 outline-blue-600" : "size-3 border-gray-300 bg-white"}`}
+									className={`rounded-full border ${currentStep === "source" || currentStep === "destination" || currentStep === "schema" || currentStep === "config" ? "size-4 border-blue-600 outline outline-2 outline-blue-600" : "size-4 border-gray-300 bg-white"}`}
 								></div>
 								<div
-									className={`h-[1px] w-16 ${currentStep === "source" || currentStep === "destination" || currentStep === "schema" || currentStep === "config" ? "bg-blue-600" : "bg-gray-300"}`}
+									className={`-mr-2 h-[2px] w-20 ${currentStep === "source" || currentStep === "destination" || currentStep === "schema" || currentStep === "config" ? "bg-blue-600" : "bg-gray-300"}`}
 								></div>
 							</div>
 							<span
-								className={`mt-2 translate-x-[-50%] text-xs ${currentStep === "source" || currentStep === "destination" || currentStep === "schema" || currentStep === "config" ? "text-blue-600" : "text-gray-500"}`}
+								className={`mt-2 translate-x-[-40%] text-xs ${currentStep === "source" || currentStep === "destination" || currentStep === "schema" || currentStep === "config" ? "text-blue-600" : "text-gray-500"}`}
 							>
 								Source
 							</span>
@@ -163,14 +163,14 @@ const JobCreation: React.FC = () => {
 						<div className="flex flex-col items-start">
 							<div className="flex items-center">
 								<div
-									className={`rounded-full border ${currentStep === "destination" || currentStep === "schema" || currentStep === "config" ? "size-2 border-blue-600 outline outline-2 outline-blue-600" : "size-3 border-gray-300 bg-white"}`}
+									className={`z-10 rounded-full border ${currentStep === "destination" || currentStep === "schema" || currentStep === "config" ? "size-4 border-blue-600 outline outline-2 outline-blue-600" : "size-4 border-gray-300 bg-white"}`}
 								></div>
 								<div
-									className={`h-[1px] w-16 ${currentStep === "schema" || currentStep === "config" ? "bg-blue-600" : "bg-gray-300"}`}
+									className={`-mr-2 h-[2px] w-20 ${currentStep === "schema" || currentStep === "config" ? "bg-blue-600" : "bg-gray-300"}`}
 								></div>
 							</div>
 							<span
-								className={`mt-2 translate-x-[-50%] text-xs ${currentStep === "destination" || currentStep === "schema" || currentStep === "config" ? "text-blue-600" : "text-gray-500"}`}
+								className={`mt-2 translate-x-[-35%] text-xs ${currentStep === "destination" || currentStep === "schema" || currentStep === "config" ? "text-blue-600" : "text-gray-500"}`}
 							>
 								Destination
 							</span>
@@ -179,14 +179,14 @@ const JobCreation: React.FC = () => {
 						<div className="flex flex-col items-start">
 							<div className="flex items-center">
 								<div
-									className={`rounded-full border ${currentStep === "schema" || currentStep === "config" ? "size-2 border-blue-600 outline outline-2 outline-blue-600" : "size-3 border-gray-300 bg-white"}`}
+									className={`z-10 rounded-full border ${currentStep === "schema" || currentStep === "config" ? "size-4 border-blue-600 outline outline-2 outline-blue-600" : "size-4 border-gray-300 bg-white"}`}
 								></div>
 								<div
-									className={`h-[1px] w-16 ${currentStep === "config" ? "bg-blue-600" : "bg-gray-300"}`}
+									className={`-mr-2 h-[2px] w-20 ${currentStep === "config" ? "bg-blue-600" : "bg-gray-300"}`}
 								></div>
 							</div>
 							<span
-								className={`mt-2 translate-x-[-50%] text-xs ${currentStep === "schema" || currentStep === "config" ? "text-blue-600" : "text-gray-500"}`}
+								className={`mt-2 translate-x-[-40%] text-xs ${currentStep === "schema" || currentStep === "config" ? "text-blue-600" : "text-gray-500"}`}
 							>
 								Schema
 							</span>
@@ -195,11 +195,11 @@ const JobCreation: React.FC = () => {
 						<div className="flex flex-col items-start">
 							<div className="flex items-center">
 								<div
-									className={`rounded-full border ${currentStep === "config" ? "size-2 border-blue-600 outline outline-2 outline-blue-600" : "size-3 border-gray-300 bg-white"}`}
+									className={`z-10 rounded-full border ${currentStep === "config" ? "size-4 border-blue-600 outline outline-2 outline-blue-600" : "size-4 border-gray-300 bg-white"}`}
 								></div>
 							</div>
 							<span
-								className={`mt-2 translate-x-[-50%] text-xs ${currentStep === "config" ? "text-blue-600" : "text-gray-500"}`}
+								className={`mt-2 translate-x-[-35%] text-xs ${currentStep === "config" ? "text-blue-600" : "text-gray-500"}`}
 							>
 								Job Config
 							</span>


### PR DESCRIPTION
This pull request includes several changes to the `JobCreation` component in the `olake_frontend/src/modules/jobs/pages/JobCreation.tsx` file to improve the visual appearance and layout of the stepper.

Closes: #7 

Improvements to the stepper layout:

* Increased the gap between stepper items by adding the `gap-2` class to the container div.
* Standardized the size of step indicators to `size-4` and adjusted the border and outline styles.
* Adjusted the width and margin of the connecting lines between steps, changing the height to `2px` and width to `20px`, and adding a negative right margin of `-mr-2`. 
* Modified the translation and alignment of step labels to improve readability, adjusting the `translate-x` value for better positioning.
* Added the `z-10` class to the step indicators to ensure they appear above other elements.

### Screenshot
![image](https://github.com/user-attachments/assets/05e34b70-2e7e-47be-b7ee-39d1551ea8cc)
