### PR TITLE
Feat/add source cancel modal

### DIFF
--- a/olake_frontend/src/modules/common/components/EntityCancelModal.tsx
+++ b/olake_frontend/src/modules/common/components/EntityCancelModal.tsx
@@ -1,9 +1,18 @@
 import { Button, Modal } from "antd"
 import { useAppStore } from "../../../store"
-import { GitCommit } from "@phosphor-icons/react"
+import { GitCommit, LinktreeLogo, Path } from "@phosphor-icons/react"
 import { useNavigate } from "react-router-dom"
+import React from "react"
 
-const SourceCancelModal = () => {
+interface EntityCancelModalProps {
+	type: string
+	navigateTo: string
+}
+
+const EntityCancelModal: React.FC<EntityCancelModalProps> = ({
+	type,
+	navigateTo,
+}) => {
 	const { showSourceCancelModal, setShowSourceCancelModal } = useAppStore()
 	const navigate = useNavigate()
 	return (
@@ -16,10 +25,22 @@ const SourceCancelModal = () => {
 		>
 			<div className="flex flex-col items-center justify-center gap-6 py-4">
 				<div className="rounded-xl bg-[#F0F0F0] p-2">
-					<GitCommit className="z-10 size-5 text-[#6E6E6E]" />
+					{type === "source" ? (
+						<LinktreeLogo className="z-10 size-6 text-[#6E6E6E]" />
+					) : type === "destination" ? (
+						<Path className="z-10 size-6 text-[#6E6E6E]" />
+					) : (
+						<GitCommit className="z-10 size-6 text-[#6E6E6E]" />
+					)}
 				</div>
 				<div className="mb-4 text-center text-xl font-medium">
-					Are you sure you want to cancel the job?
+					{type === "job"
+						? "Are you sure you want to cancel the job?"
+						: type === "job-edit"
+							? "Are you sure you want to cancel the job edit?"
+							: type === "source"
+								? "Are you sure you want to cancel the source?"
+								: "Are you sure you want to cancel the destination?"}
 				</div>
 				<div className="flex space-x-8">
 					<Button
@@ -34,7 +55,7 @@ const SourceCancelModal = () => {
 						danger
 						onClick={() => {
 							setShowSourceCancelModal(false)
-							navigate("/jobs")
+							navigate(`/${navigateTo}`)
 						}}
 					>
 						Cancel
@@ -45,4 +66,4 @@ const SourceCancelModal = () => {
 	)
 }
 
-export default SourceCancelModal
+export default EntityCancelModal

--- a/olake_frontend/src/modules/common/components/SourceCancelModal.tsx
+++ b/olake_frontend/src/modules/common/components/SourceCancelModal.tsx
@@ -1,0 +1,48 @@
+import { Button, Modal } from "antd"
+import { useAppStore } from "../../../store"
+import { GitCommit } from "@phosphor-icons/react"
+import { useNavigate } from "react-router-dom"
+
+const SourceCancelModal = () => {
+	const { showSourceCancelModal, setShowSourceCancelModal } = useAppStore()
+	const navigate = useNavigate()
+	return (
+		<Modal
+			open={showSourceCancelModal}
+			footer={null}
+			closable={false}
+			centered
+			width={400}
+		>
+			<div className="flex flex-col items-center justify-center gap-6 py-4">
+				<div className="rounded-xl bg-[#F0F0F0] p-2">
+					<GitCommit className="z-10 size-5 text-[#6E6E6E]" />
+				</div>
+				<div className="mb-4 text-center text-xl font-medium">
+					Are you sure you want to cancel the job?
+				</div>
+				<div className="flex space-x-8">
+					<Button
+						className="border border-[#D9D9D9]"
+						onClick={() => setShowSourceCancelModal(false)}
+					>
+						Don&apos;t cancel
+					</Button>
+					<Button
+						className="px-8 py-4"
+						type="primary"
+						danger
+						onClick={() => {
+							setShowSourceCancelModal(false)
+							navigate("/jobs")
+						}}
+					>
+						Cancel
+					</Button>
+				</div>
+			</div>
+		</Modal>
+	)
+}
+
+export default SourceCancelModal

--- a/olake_frontend/src/modules/destinations/pages/CreateDestination.tsx
+++ b/olake_frontend/src/modules/destinations/pages/CreateDestination.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react"
-import { useNavigate, Link } from "react-router-dom"
+import { Link } from "react-router-dom"
 import { Input, Radio, Select } from "antd"
 import { useAppStore } from "../../../store"
 import {
@@ -12,6 +12,7 @@ import TestConnectionModal from "../../common/components/TestConnectionModal"
 import TestConnectionSuccessModal from "../../common/components/TestConnectionSuccessModal"
 import EntitySavedModal from "../../common/components/EntitySavedModal"
 import DocumentationPanel from "../../common/components/DocumentationPanel"
+import EntityCancelModal from "../../common/components/EntityCancelModal"
 
 interface CreateDestinationProps {
 	fromJobFlow?: boolean
@@ -30,7 +31,6 @@ const CreateDestination: React.FC<CreateDestinationProps> = ({
 	stepNumber,
 	stepTitle,
 }) => {
-	const navigate = useNavigate()
 	const [setupType, setSetupType] = useState("new")
 	const [connector, setConnector] = useState("Amazon S3")
 	const [authType, setAuthType] = useState("iam")
@@ -49,6 +49,7 @@ const CreateDestination: React.FC<CreateDestinationProps> = ({
 		setShowTestingModal,
 		setShowSuccessModal,
 		setShowEntitySavedModal,
+		setShowSourceCancelModal,
 	} = useAppStore()
 
 	useEffect(() => {
@@ -97,13 +98,7 @@ const CreateDestination: React.FC<CreateDestinationProps> = ({
 	}, [connector, setupType, destinations])
 
 	const handleCancel = () => {
-		if (fromJobEditFlow) {
-			navigate("/jobs")
-		} else if (fromJobFlow) {
-			navigate("/jobs/new")
-		} else {
-			navigate("/destinations")
-		}
+		setShowSourceCancelModal(true)
 	}
 	const handleCreate = () => {
 		setTimeout(() => {
@@ -478,6 +473,12 @@ const CreateDestination: React.FC<CreateDestinationProps> = ({
 				type="destination"
 				onComplete={onComplete}
 				fromJobFlow={fromJobFlow || false}
+			/>
+			<EntityCancelModal
+				type="destination"
+				navigateTo={
+					fromJobEditFlow ? "jobs" : fromJobFlow ? "jobs/new" : "destinations"
+				}
 			/>
 		</div>
 	)

--- a/olake_frontend/src/modules/jobs/pages/JobCreation.tsx
+++ b/olake_frontend/src/modules/jobs/pages/JobCreation.tsx
@@ -10,6 +10,7 @@ import { useAppStore } from "../../../store"
 import EntitySavedModal from "../../common/components/EntitySavedModal"
 import SchemaConfiguration from "../components/SchemaConfiguration"
 import JobConfiguration from "../components/JobConfiguration"
+import SourceCancelModal from "../../common/components/SourceCancelModal"
 
 type Step = "source" | "destination" | "schema" | "config"
 
@@ -33,7 +34,7 @@ const JobCreation: React.FC = () => {
 	const [schemaChangeStrategy, setSchemaChangeStrategy] = useState("propagate")
 	const [notifyOnSchemaChanges, setNotifyOnSchemaChanges] = useState(true)
 
-	const { setShowEntitySavedModal } = useAppStore()
+	const { setShowEntitySavedModal, setShowSourceCancelModal } = useAppStore()
 
 	const handleNext = () => {
 		if (currentStep === "source") {
@@ -58,8 +59,12 @@ const JobCreation: React.FC = () => {
 	}
 
 	const handleCancel = () => {
-		message.info("Job creation cancelled")
-		navigate("/jobs")
+		if (currentStep === "source") {
+			setShowSourceCancelModal(true)
+		} else {
+			message.info("Job creation cancelled")
+			navigate("/jobs")
+		}
 	}
 
 	const handleSaveJob = () => {
@@ -206,6 +211,7 @@ const JobCreation: React.FC = () => {
 						fromJobFlow={false}
 						onComplete={() => navigate("/jobs")}
 					/>
+					<SourceCancelModal />
 				</div>
 			</div>
 		</div>

--- a/olake_frontend/src/modules/jobs/pages/JobCreation.tsx
+++ b/olake_frontend/src/modules/jobs/pages/JobCreation.tsx
@@ -10,7 +10,7 @@ import { useAppStore } from "../../../store"
 import EntitySavedModal from "../../common/components/EntitySavedModal"
 import SchemaConfiguration from "../components/SchemaConfiguration"
 import JobConfiguration from "../components/JobConfiguration"
-import SourceCancelModal from "../../common/components/SourceCancelModal"
+import EntityCancelModal from "../../common/components/EntityCancelModal"
 
 type Step = "source" | "destination" | "schema" | "config"
 
@@ -211,7 +211,10 @@ const JobCreation: React.FC = () => {
 						fromJobFlow={false}
 						onComplete={() => navigate("/jobs")}
 					/>
-					<SourceCancelModal />
+					<EntityCancelModal
+						type="job"
+						navigateTo="jobs"
+					/>
 				</div>
 			</div>
 		</div>

--- a/olake_frontend/src/modules/jobs/pages/JobEdit.tsx
+++ b/olake_frontend/src/modules/jobs/pages/JobEdit.tsx
@@ -9,6 +9,7 @@ import StepProgress from "../components/StepIndicator"
 import SchemaConfiguration from "../components/SchemaConfiguration"
 import JobConfiguration from "../components/JobConfiguration"
 import { useAppStore } from "../../../store"
+import EntityCancelModal from "../../common/components/EntityCancelModal"
 
 type Step = "source" | "destination" | "schema" | "config"
 
@@ -43,6 +44,9 @@ const JobEdit: React.FC = () => {
 	const job = jobs.find(j => j.id === jobId)
 	const sourceObj = sources.find(s => s.name === job?.source)
 	const destinationObj = destinations.find(d => d.name === job?.destination)
+
+	// Get the value cancel modal from the store
+	const { setShowSourceCancelModal } = useAppStore()
 
 	// Load job data on component mount
 	useEffect(() => {
@@ -93,8 +97,12 @@ const JobEdit: React.FC = () => {
 	}
 
 	const handleCancel = () => {
-		message.info("Job edit cancelled")
-		navigate("/jobs")
+		if (currentStep === "source") {
+			setShowSourceCancelModal(true)
+		} else {
+			message.info("Job edit cancelled")
+			navigate("/jobs")
+		}
 	}
 
 	const handleSaveJob = () => {
@@ -271,6 +279,10 @@ const JobEdit: React.FC = () => {
 					)}
 				</div>
 			</div>
+			<EntityCancelModal
+				type="job-edit"
+				navigateTo="jobs"
+			/>
 		</div>
 	)
 }

--- a/olake_frontend/src/modules/sources/pages/CreateSource.tsx
+++ b/olake_frontend/src/modules/sources/pages/CreateSource.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react"
-import { useNavigate, Link } from "react-router-dom"
+import { Link } from "react-router-dom"
 import { Input, Radio, Select, Switch } from "antd"
 import { useAppStore } from "../../../store"
 import {
@@ -14,6 +14,7 @@ import TestConnectionModal from "../../common/components/TestConnectionModal"
 import TestConnectionSuccessModal from "../../common/components/TestConnectionSuccessModal"
 import EntitySavedModal from "../../common/components/EntitySavedModal"
 import DocumentationPanel from "../../common/components/DocumentationPanel"
+import EntityCancelModal from "../../common/components/EntityCancelModal"
 
 interface CreateSourceProps {
 	fromJobFlow?: boolean
@@ -32,15 +33,18 @@ const CreateSource: React.FC<CreateSourceProps> = ({
 	stepNumber,
 	stepTitle,
 }) => {
-	const navigate = useNavigate()
 	const [setupType, setSetupType] = useState("new")
 	const [connector, setConnector] = useState("MongoDB")
 	const [connectionType, setConnectionType] = useState("uri")
 	const [connectionUri, setConnectionUri] = useState("")
 	const [sourceName, setSourceName] = useState("")
 	const [srvEnabled, setSrvEnabled] = useState(false)
-	const { setShowEntitySavedModal, setShowTestingModal, setShowSuccessModal } =
-		useAppStore()
+	const {
+		setShowEntitySavedModal,
+		setShowSourceCancelModal,
+		setShowTestingModal,
+		setShowSuccessModal,
+	} = useAppStore()
 	const [showAdvanced, setShowAdvanced] = useState(false)
 	const [isDocPanelCollapsed, setIsDocPanelCollapsed] = useState(false)
 	const iframeRef = useRef<HTMLIFrameElement>(null)
@@ -95,13 +99,7 @@ const CreateSource: React.FC<CreateSourceProps> = ({
 	}, [connector, setupType, sources])
 
 	const handleCancel = () => {
-		if (fromJobEditFlow) {
-			navigate("/jobs")
-		} else if (fromJobFlow) {
-			navigate("/jobs/new")
-		} else {
-			navigate("/sources")
-		}
+		setShowSourceCancelModal(true)
 	}
 
 	const handleCreate = () => {
@@ -727,6 +725,12 @@ const CreateSource: React.FC<CreateSourceProps> = ({
 				type="source"
 				onComplete={onComplete}
 				fromJobFlow={fromJobFlow || false}
+			/>
+			<EntityCancelModal
+				type="source"
+				navigateTo={
+					fromJobEditFlow ? "jobs" : fromJobFlow ? "jobs/new" : "sources"
+				}
 			/>
 		</div>
 	)

--- a/olake_frontend/src/store/index.ts
+++ b/olake_frontend/src/store/index.ts
@@ -33,6 +33,7 @@ interface AppState {
 	showTestingModal: boolean
 	showSuccessModal: boolean
 	showEntitySavedModal: boolean
+	showSourceCancelModal: boolean
 
 	// Actions - Jobs
 	fetchJobs: () => Promise<void>
@@ -69,6 +70,7 @@ interface AppState {
 	setShowTestingModal: (show: boolean) => void
 	setShowSuccessModal: (show: boolean) => void
 	setShowEntitySavedModal: (show: boolean) => void
+	setShowSourceCancelModal: (show: boolean) => void
 }
 
 export const useAppStore = create<AppState>(set => ({
@@ -101,6 +103,7 @@ export const useAppStore = create<AppState>(set => ({
 	showTestingModal: false,
 	showSuccessModal: false,
 	showEntitySavedModal: false,
+	showSourceCancelModal: false,
 
 	// Jobs actions
 	fetchJobs: async () => {
@@ -468,4 +471,5 @@ export const useAppStore = create<AppState>(set => ({
 	setShowTestingModal: show => set({ showTestingModal: show }),
 	setShowSuccessModal: show => set({ showSuccessModal: show }),
 	setShowEntitySavedModal: show => set({ showEntitySavedModal: show }),
+	setShowSourceCancelModal: show => set({ showSourceCancelModal: show }),
 }))


### PR DESCRIPTION
This pull request introduces a new `SourceCancelModal` component to the job creation process, allowing users to confirm if they want to cancel the job when they are on the source step. The most important changes include adding the modal component, integrating it into the job creation page, and updating the application state to manage the visibility of the modal.

Closes #11 

New component addition:

* [`olake_frontend/src/modules/common/components/SourceCancelModal.tsx`](diffhunk://#diff-ed339f97d4e114e59be155aafaf00564bc827289d82d3c62d756dfddc9a9d357R1-R48): Added a new `SourceCancelModal` component to prompt users for confirmation when canceling a job at the source step.

Integration into job creation page:

* [`olake_frontend/src/modules/jobs/pages/JobCreation.tsx`](diffhunk://#diff-e5fdd594ff86b7cd8ddbad33ac350c39be60d56fe5e41a30e4fc4255cba7ebd6R13): Imported the `SourceCancelModal` component, updated the state to handle the modal visibility, and included the modal in the JSX structure.

State management updates:

* [`olake_frontend/src/store/index.ts`](diffhunk://#diff-61e3514845f4fc0dea4f66bb21cff44ca638e097baa2c5160dc5dcdacacdae8cR36): Added `showSourceCancelModal` and `setShowSourceCancelModal` to the application state to control the visibility of the new modal. 


![image](https://github.com/user-attachments/assets/84c5500c-4a1b-4bfa-a974-ecfde3bc0c44)
