### PR TITLE
fix: sync StreamPanel checkbox state with selectedStreams

### DIFF
--- a/olake_frontend/src/modules/jobs/pages/streams/StreamPanel.tsx
+++ b/olake_frontend/src/modules/jobs/pages/streams/StreamPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, useEffect } from "react"
+import { useCallback, useMemo } from "react"
 import { StreamPanelProps } from "../../../../types"
 import StreamHeader from "./StreamHeader"
 import { CheckboxChangeEvent } from "antd"
@@ -10,18 +10,10 @@ const StreamPanel: React.FC<StreamPanelProps> = ({
 	onStreamSelect,
 	isSelected,
 }) => {
-	const [checked, setChecked] = useState(isSelected)
-
-	// Update checked state when isSelected prop changes
-	useEffect(() => {
-		setChecked(isSelected)
-	}, [isSelected])
-
 	const toggle = useCallback(
 		(e: CheckboxChangeEvent) => {
 			const { checked } = e.target
 			e.stopPropagation() // hack to prevent configuration triggers
-			setChecked(checked)
 			onStreamSelect?.(stream.stream.name, checked)
 		},
 		[stream, onStreamSelect],
@@ -38,13 +30,13 @@ const StreamPanel: React.FC<StreamPanelProps> = ({
 				<StreamHeader
 					stream={stream}
 					toggle={toggle}
-					checked={checked}
+					checked={isSelected}
 					activeStreamData={activeStreamData}
 					setActiveStreamData={setActiveStreamData}
 				/>
 			),
 		}
-	}, [stream, checked, activeStreamData, setActiveStreamData, toggle])
+	}, [stream, isSelected, activeStreamData, setActiveStreamData, toggle])
 
 	return <div>{header}</div>
 }


### PR DESCRIPTION
- Removed the redundant `checked` local state.
- StreamPanel now directly uses the `isSelected` prop as the source of truth.